### PR TITLE
[임근홍] add: list 페이지 레이아웃, UI구현

### DIFF
--- a/src/pages/list/List.js
+++ b/src/pages/list/List.js
@@ -1,7 +1,83 @@
 import React from 'react';
+import style from '../list/List.module.css';
 
 function List() {
-  return <div />;
+  return (
+    <div>
+      <center className={style.listHeaderWap}>
+        <p>FIND STAY</p>
+        <p>머무는 것 자체로 여행이 되는 공간</p>
+      </center>
+
+      <section className={style.listFilter}>
+        <div className={style.listFilterSearch}>
+          <div>
+            <div className={style.searchBar}>
+              <p>여행지/숙소</p>
+              <input type="search" />
+              <button>국내전체</button>
+            </div>
+
+            <section className={style.modalOverlay}>
+              <div className="modalWindow">
+                <div className="title">
+                  <h2>어디로 떠날까요?</h2>
+                </div>
+                <div className="xButton">X</div>
+                <div>
+                  <div className="componet">
+                    <h3>국내</h3>
+                    <div>map으로 받기</div>
+                  </div>
+                  <div className="componet">
+                    <h3>해외</h3>
+                    <div>map으로</div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <div className="checkIn">
+              <p>체크인</p>
+              <div className="calendar">
+                <input type="date" />
+              </div>
+            </div>
+            <div className="checkOut">
+              <p>체크아웃</p>
+              <div className="calendar">
+                <input type="date" />
+              </div>
+            </div>
+          </div>
+          <div className={style.reButton}>
+            <button>
+              <img
+                className={style.reButtonImg}
+                src="https://user-images.githubusercontent.com/85507868/160820139-6ec16112-30c2-4ec3-b28e-9c9a95f63a06.png"
+                alt="rebutton"
+              />
+            </button>
+          </div>
+        </div>
+        <div className={style.listFilterNoneSearch}>
+          <div>
+            <button>인원</button>
+          </div>
+          <div>
+            <button>가격 범위</button>
+          </div>
+          <div>
+            <button>스테이 유형</button>
+          </div>
+        </div>
+      </section>
+
+      <center className={style.listSearchbutton}>
+        <button>SEARCH →</button>
+      </center>
+    </div>
+  );
 }
 
 export default List;

--- a/src/pages/list/List.module.css
+++ b/src/pages/list/List.module.css
@@ -1,0 +1,121 @@
+button {
+  font-size: 16px;
+}
+
+.listHeaderWap {
+  display: flex;
+  flex-direction: column;
+  padding: 180px 0 100px 0;
+}
+
+.listHeaderWap p:not(:last-child) {
+  margin-bottom: 20px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 22px;
+  font-weight: bold;
+  letter-spacing: 15px;
+}
+
+.listFilter {
+  display: flex;
+  flex-direction: column;
+  margin: auto;
+  padding: 0 30px;
+  max-width: 1500px;
+  min-width: 1100px;
+}
+
+.listFilterSearch {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 15px;
+  border-top: 3px solid black;
+  border-bottom: 1px solid rgb(204, 204, 204);
+}
+
+.listFilterSearch * {
+  display: flex;
+  align-items: center;
+  margin-bottom: 6px;
+  padding-right: 15px;
+  width: max-content;
+}
+
+.searchBar {
+  margin-right: 30px;
+  font-weight: bold;
+}
+
+.searchBar input[type='search'] {
+  margin-right: 10px;
+  padding: 8px 3px 8px 10px;
+  border: 1px solid silver;
+  border-radius: 3px;
+  font-size: 16px;
+}
+
+.searchBar button {
+  padding: 8px 75px 8px 15px;
+  border: none;
+  border-radius: 4px;
+  background-color: rgb(243, 243, 243);
+}
+
+.modalOverlay {
+  display: none;
+}
+
+.reButton {
+  padding-right: 0px;
+}
+
+.reButton button {
+  border: 1px solid silver;
+  border-radius: 4px;
+  background-color: transparent;
+  padding: 3px 4px 0 4px;
+}
+
+.reButtonImg {
+  padding: 7px;
+  width: 30px;
+  height: auto;
+}
+
+.listFilterNoneSearch {
+  display: flex;
+  border-bottom: 1px solid rgb(204, 204, 204);
+}
+
+.listFilterNoneSearch div {
+  margin-right: 20px;
+  padding: 10px 0;
+}
+
+.listFilterNoneSearch div button {
+  padding: 8px 10px 8px 15px;
+  border: 1px solid silver;
+  border-radius: 4px;
+  background-color: transparent;
+  width: 200px;
+  background-image: url(https://user-images.githubusercontent.com/85507868/160812110-52a487f9-7744-4979-86dc-b7a6385ba96f.png);
+  background-position: 90% center;
+  background-size: 13px;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  text-align: left;
+}
+
+.listSearchbutton {
+  margin-top: 40px;
+}
+
+.listSearchbutton button {
+  border: none;
+  border-radius: 50px;
+  padding: 10px 20px 10px 30px;
+  width: max-content;
+  background-color: black;
+  color: whitesmoke;
+  letter-spacing: 3px;
+}


### PR DESCRIPTION
### 깃브랜치오류로 feature/list 브랜치로 옮겼습니다. feature/list-filter는 사용하지 않는 브랜치입니다!

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [x] 레이아웃 구현

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 리스트 페이지 필터 레이아웃 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
필터부분이 대부분 모달이라서 일단 레이아웃만 구현해뒀습니다.
- 레이아웃만 구현하여 기능은 작동하지 않습니다

따로 써야하는 폰트가 있어서 파일 내에 import했습니다. 

체크인, 체크아웃은 방법 결정되면 진행하려고 일단 자리에만 뒀습니다. 

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- background-image를 사용해보았습니다. 
- 모달에 대한 고민을 했습니다. 
- position에 따라 위치값을 추가해줘야합니다.

<br />

## :: 기타 질문 및 특이 사항
- ㅎㅎ...common 폰트 사용하면 레이아웃을 더 만져봐야할 것 같습니다.
- 지금 발견했는데 여행지/숙소부분 hover 효과를 빼줘야할 것 같네요
