### PR TITLE
[전하은] Detail 페이지 레이아웃 1차 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,10 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <script
+      src="https://kit.fontawesome.com/34628dbe1f.js"
+      crossorigin="anonymous"
+    ></script>
     <title>React App</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -8,10 +8,6 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <script
-      src="https://kit.fontawesome.com/34628dbe1f.js"
-      crossorigin="anonymous"
-    ></script>
     <title>React App</title>
   </head>
   <body>

--- a/src/components/detailTop/DetailTop.js
+++ b/src/components/detailTop/DetailTop.js
@@ -4,19 +4,21 @@ import styles from './DetailTop.module.scss';
 const DetailTop = () => {
   return (
     <div className={styles.top}>
-      {/* 숙소명 */}
-      <span className={styles.title}>숙소명</span>
-
-      {/* 숙소 사진 슬라이드 */}
-      <div className={styles.dormImg}>img slide</div>
-
-      {/* 숙소 이름 + 날짜 선택 */}
+      {/* 숙소명 및 날짜 선택*/}
       <div className={styles.calendar}>
-        <span className={styles.middleTitle}>숙소명</span>
-        <div className={styles.day}>
-          <div className={styles.selectBtn}>날짜를 선택해주세요.</div>
+        <div className={styles.title_container}>
+          <span className={styles.title}>어연스테이</span>
+          <div className={styles.date}>
+            <div className={styles.select_btn}>
+              <span className={styles.select_date}>날짜를 선택해주세요.</span>
+              <i class="fa-solid fa-chevron-down" />
+            </div>
+            <div className={styles.date_blank} />
+          </div>
         </div>
       </div>
+      {/* 숙소 사진 슬라이드 */}
+      <div className={styles.dorm_img}>img slide</div>
     </div>
   );
 };

--- a/src/components/detailTop/DetailTop.js
+++ b/src/components/detailTop/DetailTop.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import styles from './DetailTop.module.scss';
+
+const DetailTop = () => {
+  return (
+    <div className={styles.top}>
+      {/* 숙소명 */}
+      <span className={styles.title}>숙소명</span>
+
+      {/* 숙소 사진 슬라이드 */}
+      <div className={styles.dormImg}>img slide</div>
+
+      {/* 숙소 이름 + 날짜 선택 */}
+      <div className={styles.calendar}>
+        <span className={styles.middleTitle}>숙소명</span>
+        <div className={styles.day}>
+          <div className={styles.selectBtn}>날짜를 선택해주세요.</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DetailTop;

--- a/src/components/detailTop/DetailTop.module.scss
+++ b/src/components/detailTop/DetailTop.module.scss
@@ -1,13 +1,50 @@
-.title {
-  font-size: 80px;
+* {
+  font-family: 'Spoqa Han Sans Neo', 'sans-serif';
 }
 
-.dormImg {
-  width: 800px;
+.calendar {
+  margin: 40px 30px;
+}
+
+.title_container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 15px;
+  width: 100%;
+}
+
+.title {
+  font-size: 40px;
+  font-weight: 500;
+  width: 50%;
+}
+
+.date {
+  display: flex;
+  justify-content: space-between;
+  width: 50%;
+}
+
+.select_btn {
+  margin-left: 5px;
+}
+
+.select_btn:hover {
+  cursor: pointer;
+}
+
+.select_date {
+  margin-right: 5px;
+}
+
+.dorm_img {
+  width: 100%;
   height: 500px;
   background-color: gray;
 }
 
 .calendar {
-  border-bottom: 2px solid gray;
+  border-bottom: 2px solid lightgray;
 }

--- a/src/components/detailTop/DetailTop.module.scss
+++ b/src/components/detailTop/DetailTop.module.scss
@@ -1,0 +1,13 @@
+.title {
+  font-size: 80px;
+}
+
+.dormImg {
+  width: 800px;
+  height: 500px;
+  background-color: gray;
+}
+
+.calendar {
+  border-bottom: 2px solid gray;
+}

--- a/src/components/detailTop/DetailTop.module.scss
+++ b/src/components/detailTop/DetailTop.module.scss
@@ -1,7 +1,3 @@
-* {
-  font-family: 'Spoqa Han Sans Neo', 'sans-serif';
-}
-
 .calendar {
   margin: 40px 30px;
 }

--- a/src/components/faq/FAQ.js
+++ b/src/components/faq/FAQ.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const FAQ = () => {
+  return (
+    <div>
+      
+    </div>
+  );
+};
+
+export default FAQ;

--- a/src/components/info/Info.js
+++ b/src/components/info/Info.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Info = () => {
+  return (
+    <div>
+      
+    </div>
+  );
+};
+
+export default Info;

--- a/src/components/info/Info.js
+++ b/src/components/info/Info.js
@@ -1,9 +1,36 @@
 import React from 'react';
+import css from './Info.module.scss';
 
 const Info = () => {
   return (
-    <div>
-      
+    <div className={css.container}>
+      <div className={css.topDescription}>
+        <h1>모든 것을 내려 놓으며, 비로소 느낄 수 있는 머무름의 시간</h1>
+        <p className={css.dormName}>어 연 스 테 이</p>
+      </div>
+      <div className={css.middleLine} />
+      <div className={css.mainDescription}>
+        <p>
+          어연 스테이는 전북 완주군 소양면 오성 한옥 마을 내에 위치한
+          풀빌라입니다. 자연 친화적인 180평의 넓은 공간을 단독으로 사용할 수
+          있습니다. 주변은 한옥이 어우러져 있으며 스테이의 앞과 뒤에는 산이,
+          <br />
+          옆으로는 계곡이 흘러 객실 내에서도 항상 계곡 흐르는 소리가 잔잔하게
+          들려 <br />
+          명상이나 사색에도 좋은 공간, 어연스테이 입니다.
+        </p>
+      </div>
+      <div className={css.bottomDescription}>
+        <p>
+          20년 전에 지은 황토 주택을 리모델링하여 탄생한 어연스테이는 우드와
+          화이트 톤으로 정갈하면서도 편안함을 추구합니다. 외부는 이국적이지만
+          내부는 한국적인 아름다움과 멋을 느낄 수 있으며, 건물 뒤쪽으로는
+          게스트만이 사용 가능한 원두막과 아이들이
+          <br /> 뛰어 놀 수 있는 잔디정원이 있습니다. 시시각각 변하는 계절의
+          특색에 맞게 창문으로 보여지는 자연 경관이
+          <br /> 하나의 갤러리를 연상시킵니다.
+        </p>
+      </div>
     </div>
   );
 };

--- a/src/components/info/Info.module.scss
+++ b/src/components/info/Info.module.scss
@@ -1,0 +1,42 @@
+* {
+  font-family: 'Spoqa Han Sans Neo', 'sans-serif';
+}
+
+.container {
+  position: relative;
+  margin: 100px auto;
+  width: 60%;
+  text-align: center;
+}
+
+.topDescription {
+  font-size: 25px;
+  font-weight: 400;
+}
+
+.dormName {
+  margin: 20px 0;
+  font-weight: 350;
+  font-size: 15px;
+}
+
+.middleLine {
+  position: absolute;
+  border-left: 1.5px solid black;
+  left: 50%;
+  height: 40px;
+}
+
+.mainDescription {
+  margin-top: 80px;
+  font-size: 16px;
+  letter-spacing: 1px;
+  line-height: 30px;
+}
+
+.bottomDescription {
+  margin-top: 40px;
+  font-size: 13px;
+  letter-spacing: 1px;
+  line-height: 25px;
+}

--- a/src/components/location/Location.js
+++ b/src/components/location/Location.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Location = () => {
+  return (
+    <div>
+      
+    </div>
+  );
+};
+
+export default Location;

--- a/src/components/rooms/Rooms.js
+++ b/src/components/rooms/Rooms.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Rooms = () => {
+  return (
+    <div>
+      
+    </div>
+  );
+};
+
+export default Rooms;

--- a/src/components/rooms/Rooms.js
+++ b/src/components/rooms/Rooms.js
@@ -1,9 +1,16 @@
 import React from 'react';
-
+import styles from './Rooms.module.scss';
 const Rooms = () => {
   return (
-    <div>
-      
+    <div className={styles.container}>
+      <div className={styles.gray_box}>
+        <div className={styles.info}>
+          <h1 className={styles.title}>ROOMS</h1>
+          <div className={styles.border_line} />
+          <h4 className={styles.description}>내려놓는 시간 내려 놓는 마음</h4>
+        </div>
+      </div>
+      <div className={styles.white_box} />
     </div>
   );
 };

--- a/src/components/rooms/Rooms.module.scss
+++ b/src/components/rooms/Rooms.module.scss
@@ -1,0 +1,31 @@
+.container {
+  width: 100%;
+}
+
+.gray_box {
+  display: flex;
+  align-items: center;
+  width: 50%;
+  height: 500px;
+  background-color: #f5f5f5;
+}
+
+.title {
+  padding-left: 20px;
+  font-size: 40px;
+  font-weight: 800;
+}
+
+.border_line {
+  margin: 20px;
+  border-bottom: 5px solid black;
+  width: 40%;
+}
+
+.description {
+  padding: 20px 20px;
+}
+
+.white_box {
+  width: 50%;
+}

--- a/src/components/special/Special.js
+++ b/src/components/special/Special.js
@@ -1,9 +1,35 @@
 import React from 'react';
+import css from './Special.module.scss';
 
 const Special = () => {
   return (
-    <div>
-      
+    <div className={css.container}>
+      <div className={css.special}>
+        <h1>SPECIAL</h1>
+      </div>
+      <div className={css.cardWrapper}>
+        <div className={css.card}>
+          <h1 className={css.title}>MUSIC</h1>
+          <p className={css.description}>
+            강력하고도 정교한 사운드를 선사하는 뱅앤올룹슨 A9 스피커가 마련되어
+            있습니다. 풍부한 음질과 함께 품격 있는 시간을 가질 수 있습니다.
+          </p>
+        </div>
+        <div className={css.card}>
+          <h1 className={css.title}>NATURE</h1>
+          <p className={css.description}>
+            산이 펼쳐지고 물이 흐르는 곳에 자리하여 큰 창 가득 완주의 자연을
+            끌어안는 공간입니다.
+          </p>
+        </div>
+        <div className={css.card}>
+          <h1 className={css.title}>BATH</h1>
+          <p className={css.description}>
+            외부의 시선으로부터 자유로운 야외 소프트 욕조에서 자연의 치유력을
+            느끼며 몰튼 브라운 어메니티로 피로를 풀어보세요.
+          </p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/special/Special.js
+++ b/src/components/special/Special.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Special = () => {
+  return (
+    <div>
+      
+    </div>
+  );
+};
+
+export default Special;

--- a/src/components/special/Special.module.scss
+++ b/src/components/special/Special.module.scss
@@ -1,0 +1,42 @@
+.container {
+  padding-bottom: 100px;
+  background-color: gray;
+  color: white;
+  background-image: url('https://images.unsplash.com/photo-1523217582562-09d0def993a6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80');
+}
+
+.special {
+  padding: 80px 0;
+  text-align: center;
+  font-size: 25px;
+  letter-spacing: 15px;
+}
+
+.cardWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  width: 100%;
+}
+
+.card {
+  width: 25%;
+  padding: 50px 10px;
+  background-color: black;
+  opacity: 60%;
+}
+
+.title {
+  padding: 30px 0;
+  font-size: 20px;
+  text-align: center;
+}
+
+.description {
+  margin: 0 auto;
+  width: 80%;
+  text-align: center;
+  font-size: 13px;
+  letter-spacing: 2px;
+  line-height: 20px;
+}

--- a/src/pages/detail/Detail.js
+++ b/src/pages/detail/Detail.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import DetailTop from '../../components/detailTop/DetailTop';
+import Rooms from '../../components/rooms/Rooms';
 import styles from './Detail.module.scss';
 
 function Detail() {
   return (
     <>
       <DetailTop />
+      <Rooms />
     </>
   );
 }

--- a/src/pages/detail/Detail.js
+++ b/src/pages/detail/Detail.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import DetailTop from '../../components/detailTop/DetailTop';
+import Info from '../../components/info/Info';
 import Rooms from '../../components/rooms/Rooms';
+import Special from '../../components/special/Special';
 import styles from './Detail.module.scss';
 
 function Detail() {
@@ -8,6 +10,8 @@ function Detail() {
     <>
       <DetailTop />
       <Rooms />
+      <Info />
+      <Special />
     </>
   );
 }

--- a/src/pages/detail/Detail.js
+++ b/src/pages/detail/Detail.js
@@ -1,7 +1,13 @@
 import React from 'react';
+import DetailTop from '../../components/detailTop/DetailTop';
+import styles from './Detail.module.scss';
 
 function Detail() {
-  return <div />;
+  return (
+    <>
+      <DetailTop />
+    </>
+  );
 }
 
 export default Detail;

--- a/src/pages/detail/Detail.module.scss
+++ b/src/pages/detail/Detail.module.scss
@@ -1,0 +1,1 @@
+@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);

--- a/src/pages/detail/Detail.module.scss
+++ b/src/pages/detail/Detail.module.scss
@@ -1,1 +1,0 @@
-@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,3 +1,6 @@
+@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);
+
 * {
   box-sizing: border-box;
+  font-family: 'Spoqa Han Sans Neo', 'sans-serif';
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [x] 레이아웃 구현

<br />

## :: 구현 목표
- 디테일 페이지 레이아웃 1차 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 디테일 페이지 레이아웃 구성 1차 구현 완료
2. 지도와 FAQ 부분은 API 및 컴포넌트를 복잡하게 들고와야 할 것 같아서 2차 때 구현하도록 하겠습니다.
3. 하트/슬라이드/달력/ROOM 사진 출력은 2차 레이아웃 때 구현하도록 하겠습니다.
4. flex로 배치를 하다보니 의미없는 요소를 사용하게 되는데 더 고민해보도록 하겠습니다.
5. stayfolio의 원래 레이아웃과는 차이가 있습니다. 디자인적으로 불필요한 부분은 임의로 수정했습니다.
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- flex를 좀 더 사용해보면서 더 익힐 수 있었습니다.
<br />

## :: 기타 질문 및 특이 사항
- CSS 작성 순서가 조금 뒤죽박죽인데 레이아웃 모두 구현하면 변경하도록 하겠습니다.
- module.scss 파일 불러올 때 import할 이름 통일하면 좋을 것 같아요. 저는 styles -> css로 변경했는데 한 번 애기해봅시다
