### PR TITLE
[김수빈] 메인페이지 중간 슬라이드 프론트 완성

### DIFF
--- a/src/components/nav/Nav.module.css
+++ b/src/components/nav/Nav.module.css
@@ -13,7 +13,7 @@
   width: 95%;
   position: fixed;
   height: 80px;
-  border-bottom: 1px solid gray;
+  border-bottom: 1px solid #f5f5f5;
 }
 
 .logo {
@@ -23,7 +23,7 @@
   text-decoration: none;
   font-weight: bold;
   color: black;
-  font-size: 16px;
+  font-size: 17px;
   transform: translate(0, -50%);
 }
 

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import style from './Main.module.css';
 import MainContact from './components/contact/MainContact';
+import SliderMedium from './components/sliderMedium/SliderMedium';
 
 function Main() {
   const mainRef = useRef();
@@ -11,8 +12,9 @@ function Main() {
         slider big 1
       </div>
       <div className={style.sliderSmall}>slider small 1</div>
-      <div className={style.mainBanner}>banner</div>
-      <div className={style.sliderMedium}>slider medium 1</div>
+      <div className={style.sliderMedium}>
+        <SliderMedium />
+      </div>
       <div className={style.sliderSmall}>slider small 2</div>
       <div className={style.sliderBig}>slider big 2</div>
       <div className={style.travelList}>travel list</div>

--- a/src/pages/main/Main.module.css
+++ b/src/pages/main/Main.module.css
@@ -2,10 +2,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-weight: bold;
-  font-size: 30px;
   height: 800px;
-  border: 1px solid black;
 }
 .mainFirst {
   padding-top: 80px;
@@ -16,51 +13,27 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-weight: bold;
-  font-size: 30px;
   height: 600px;
-  background: gray;
-  border: 1px solid black;
+  background: #f5f5f5;
 }
 
 .sliderSmall {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-weight: bold;
-  font-size: 30px;
   height: 400px;
-  border: 1px solid black;
-}
-
-.mianBanner {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-weight: bold;
-  font-size: 30px;
-  height: 200px;
-  background: url('https://cdn.pixabay.com/photo/2017/12/11/21/17/bridge-3013297_960_720.jpg');
-  background-size: cover;
-  border: 1px solid black;
 }
 
 .travelList {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-weight: bold;
-  font-size: 30px;
   height: 1500px;
-  border: 1px solid black;
 }
 
 .hashtagList {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-weight: bold;
-  font-size: 30px;
   height: 500px;
-  border: 1px solid black;
 }

--- a/src/pages/main/components/sliderMedium/SliderMedium.js
+++ b/src/pages/main/components/sliderMedium/SliderMedium.js
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import style from './SliderMedium.module.css';
+
+function SliderMedium() {
+  const [current, setCurrent] = useState(0);
+  const slide = [
+    {
+      id: 1,
+      url: 'https://cdn.pixabay.com/photo/2017/09/09/18/25/living-room-2732939__340.jpg',
+    },
+    {
+      id: 2,
+      url: 'https://cdn.pixabay.com/photo/2015/10/20/18/57/furniture-998265__480.jpg',
+    },
+    {
+      id: 3,
+      url: 'https://cdn.pixabay.com/photo/2014/08/11/21/39/wall-416060__340.jpg',
+    },
+
+    {
+      id: 4,
+      url: 'https://cdn.pixabay.com/photo/2017/07/09/03/19/home-2486092__340.jpg',
+    },
+  ];
+
+  const next = () => {
+    setCurrent(() => (current === slide.length - 1 ? 0 : current + 1));
+  };
+  const prev = () => {
+    setCurrent(() => (current === 0 ? slide.length - 1 : current - 1));
+  };
+
+  const order = current + 1;
+
+  return (
+    <div className={style.container}>
+      {slide.map((el, idx) => {
+        return (
+          <div
+            className={`${
+              idx === current ? style.slideActive : style.slideNonActive
+            } ${style.wrapper}`}
+            key={el.id}
+          >
+            {idx === current && (
+              <div className={style.contentsSection}>
+                <div className={style.textSection}>
+                  <p className={style.slideMainDesc}>
+                    숙소메인설명
+                    <br />
+                    변수지정{el.id}
+                  </p>
+                  <p className={style.slideSubDesc}>숙소 1줄 설명{el.id}</p>
+                  <div className={style.infoSection}>
+                    <h3 className={style.slideTitle}>숙소 이름 {el.id}</h3>
+                    <p className={style.slidePlace}>
+                      도시{el.id} / 시구군{el.id}· 숙소유형{el.id}
+                    </p>
+                    <p className={style.slidePeople}>인원{el.id}</p>
+                    <p className={style.slidePrice}>가격{el.id}</p>
+                  </div>
+                </div>
+                <Link to="/detail">
+                  <img className={style.slideImage} src={el.url} alt={el.id} />
+                </Link>
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <div className={style.promotion}>PROMOTION</div>
+      <div className={style.btns}>
+        <p onClick={prev}>&lt;</p>
+        <p onClick={next}>&gt;</p>
+      </div>
+      <div className={style.order}>
+        {order}
+        <span className={style.total}> / 4</span>
+      </div>
+    </div>
+  );
+}
+
+export default SliderMedium;

--- a/src/pages/main/components/sliderMedium/SliderMedium.module.css
+++ b/src/pages/main/components/sliderMedium/SliderMedium.module.css
@@ -1,0 +1,75 @@
+.container {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1200px;
+}
+
+.slideActive {
+  opacity: 1;
+  transition-duration: 2s;
+  width: 100%;
+}
+.slideNonActive {
+  opacity: 0;
+  transition-duration: 4s;
+}
+.contentsSection {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+.slideImage {
+  width: 900px;
+  height: 500px;
+}
+
+.slideMainDesc {
+  margin-top: 100px;
+  line-height: 40px;
+  font-size: 30px;
+}
+
+.slideSubDesc {
+  margin-top: 20px;
+  font-size: 14px;
+}
+.infoSection {
+  margin-top: 120px;
+  font-size: 15px;
+}
+.slideTitle {
+  font-size: 20px;
+  margin-bottom: 30px;
+}
+
+.btns {
+  position: absolute;
+  bottom: 0;
+  left: 4%;
+  display: flex;
+  cursor: pointer;
+  font-size: 25px;
+}
+.slidePlace,
+.slidePeople {
+  margin-bottom: 10px;
+}
+.promotion {
+  position: absolute;
+  top: 0%;
+  left: 0%;
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: 10px;
+}
+.order {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  line-height: 22px;
+}
+.total {
+  color: gray;
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인페이지에 중간사이즈의 슬라이드 구현 및 디자인

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 메인페이지에 중간슬라이드 (가장큰 슬라이드와 여러개를 보여주는 작은 슬라이드 제외 1개짜리 fade in&out을 하는 슬라이드)의 레이아웃 구현 및 디자인 완성.


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- map과 조건부 랜더링을 통해 원하는 페이지만을 보여주고 버튼을 누르면 다음 컨텐츠를 fade-in / fade-out 애니메이션을 통해 보여주는 슬라이드 형식을 구현 하였습니다.
-  map을 통해 조건부 랜더링이 필요한 부분만을 선택하고 그 외에  map안에서 구현이 힘든 것들은 state 상태를 변수에 담아서 화면에 출력해주었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 중간사이즈의 슬라이드의 슬라이드 애니메이션은 아직 실제 스테이폴리오 사이트와의 차이가 있어 방법을 더 찾아보아야 할 것 같습니다.
- 스테이폴리오의 메인페이지를 확인해보니 이전엔 있었던 베너(슬라이드가 아닌 그냥 이미지로만 되어있는)가 사라진듯 합니다. 그래서 그냥 이미지에 글자만 구현되어있는 간단한 배너였어서, 지금 슬라이드를 구현하면서 배너 부분은 제외 시켰습니다.
