### PR TITLE
[전하은] 디테일 페이지 : 슬라이드 기능 구현

### DIFF
--- a/src/pages/detail/detailTop/DetailTop.js
+++ b/src/pages/detail/detailTop/DetailTop.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import style from './DetailTop.module.css';
 import { FiHeart } from 'react-icons/fi';
 import { FaHeart } from 'react-icons/fa';
+import DormSlide from './DormSlide';
 
 const DetailTop = () => {
   const [isLike, setIsLike] = useState(false);
@@ -39,7 +40,7 @@ const DetailTop = () => {
         </div>
       </div>
       {/* 숙소 사진 슬라이드 */}
-      <div className={style.dorm_img} />
+      <DormSlide />
     </div>
   );
 };

--- a/src/pages/detail/detailTop/DormSlide.js
+++ b/src/pages/detail/detailTop/DormSlide.js
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import style from './DormSlide.module.css';
+import classNames from 'classnames/bind';
+import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
+
+const DormSlide = ({ dormName }) => {
+  const [current, setCurrent] = useState(0);
+
+  const cx = classNames.bind(style);
+
+  const slide = [
+    {
+      id: 1,
+      url: 'https://images.unsplash.com/photo-1598605272254-16f0c0ecdfa5?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2071&q=80',
+    },
+    {
+      id: 2,
+      url: 'https://images.unsplash.com/photo-1623718649591-311775a30c43?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80',
+    },
+    {
+      id: 3,
+      url: 'https://images.unsplash.com/photo-1584132869994-873f9363a562?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80',
+    },
+  ];
+
+  const next = () => {
+    setCurrent(() => (current === slide.length - 1 ? 0 : current + 1));
+  };
+
+  const prev = () => {
+    setCurrent(() => (current === 0 ? slide.length - 1 : current - 1));
+  };
+
+  return (
+    <div className={cx('container')}>
+      {slide.map((el, idx) => {
+        return (
+          <div
+            className={cx(
+              'wrapper',
+              idx === current ? 'slideActive' : 'slideInactive'
+            )}
+            key={el.id}
+          >
+            {idx === current && (
+              <img className={cx('slideImg')} src={el.url} alt={el.id} />
+            )}
+          </div>
+        );
+      })}
+      <div className={cx('prevBtn', 'btnWrapper')} onClick={prev}>
+        <IoIosArrowBack className={cx('btn')} size="20" color="white" />
+      </div>
+      <div className={cx('nextBtn', 'btnWrapper')} onClick={next}>
+        <IoIosArrowForward className={cx('btn')} size="20" color="white" />
+      </div>
+      <div className={cx('description')}>
+        <p className={cx('quote')}>여름 햇살 아래 구옥이 품은 빈티지</p>
+        <div className={cx('category')}>
+          <p className={cx('categoryName', 'magazine')}>MAGAZINE</p>
+          <p className={cx('categoryName', 'pick')}>PICK</p>
+          <p className={cx('categoryName', 'promotion')}>PROMOTION</p>
+        </div>
+        <div className={cx('dormInfo')}>
+          <p className={cx('dormName')}>'dormName'</p>
+          <p className={cx('location')}>'location'/ 'district'</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DormSlide;

--- a/src/pages/detail/detailTop/DormSlide.module.css
+++ b/src/pages/detail/detailTop/DormSlide.module.css
@@ -1,0 +1,102 @@
+.container {
+  position: relative;
+}
+
+.slideActive {
+  opacity: 1;
+  transition-duration: 2s;
+  width: 100%;
+}
+
+.slideInactive {
+  opacity: 0;
+  transition-duration: 4s;
+}
+
+.slideImg {
+  min-width: 1600px;
+  max-height: 650px;
+  height: auto;
+  width: auto;
+}
+
+.btnWrapper {
+  width: 1px;
+  padding: 15px 25px;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.btnWrapper:hover {
+  width: 1px;
+  padding: 15px 25px;
+  background-color: rgba(0, 0, 0, 0.8);
+  cursor: pointer;
+}
+
+.prevBtn {
+  position: absolute;
+  left: 0;
+  top: 40%;
+}
+
+.nextBtn {
+  position: absolute;
+  right: 0;
+  top: 40%;
+}
+
+.description {
+  display: flex;
+  align-items: center;
+  position: absolute;
+  margin-left: 20%;
+  bottom: 4px;
+  width: 60%;
+  height: 80px;
+  background-color: rgba(0, 0, 0, 0.9);
+}
+
+.quote {
+  margin: 0 180px 0 30px;
+  font-size: 20px;
+  color: white;
+}
+
+.category {
+  display: flex;
+  flex-wrap: wrap;
+  color: gray;
+}
+
+.pick {
+  color: white;
+}
+
+.categoryName {
+  font-size: 15px;
+  font-weight: 700;
+  margin-right: 25px;
+}
+
+.dormInfo {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 80px;
+  height: 100%;
+  border-left: 1px solid rgba(255, 255, 255, 0.4);
+  color: white;
+  text-align: center;
+  line-height: 20px;
+}
+
+.dormName {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.location {
+  font-size: 11px;
+  font-weight: 300px;
+  color: gray;
+}

--- a/src/pages/detail/rooms/Rooms.js
+++ b/src/pages/detail/rooms/Rooms.js
@@ -1,9 +1,36 @@
-import React from 'react';
+import React, { useState } from 'react';
 import RoomImg from './roomImg/RoomImg';
 import style from './Rooms.module.css';
 import { IoCaretBackCircle, IoCaretForwardCircle } from 'react-icons/io5';
 
 const Rooms = () => {
+  const slide = [
+    {
+      id: 1,
+      url: 'https://images.unsplash.com/photo-1564078516393-cf04bd966897?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8M3x8cm9vbXxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=600&q=60',
+    },
+    {
+      id: 2,
+      url: 'https://images.unsplash.com/photo-1564078516393-cf04bd966897?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8M3x8cm9vbXxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=600&q=60',
+    },
+    {
+      id: 3,
+      url: 'https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTF8fHJvb218ZW58MHx8MHx8&auto=format&fit=crop&w=600&q=60',
+    },
+  ];
+
+  const [currentRoom, setCurrentRoom] = useState(0);
+
+  const next = () => {
+    setCurrentRoom(() =>
+      currentRoom === slide.length - 1 ? slide.length - 1 : currentRoom + 1
+    );
+  };
+
+  const prev = () => {
+    setCurrentRoom(() => (currentRoom === 0 ? 0 : currentRoom - 1));
+  };
+
   return (
     <div className={style.container}>
       <div className={style.gray_box}>
@@ -13,18 +40,26 @@ const Rooms = () => {
           <h4 className={style.description}>내려놓는 시간 내려 놓는 마음</h4>
           <div className={style.buttons}>
             <div className={style.button}>
-              <IoCaretBackCircle size="60" />
+              <IoCaretBackCircle size="60" onClick={prev} />
             </div>
             <div className={style.button}>
-              <IoCaretForwardCircle size="60" />
+              <IoCaretForwardCircle size="60" onClick={next} />
             </div>
           </div>
         </div>
       </div>
-      <div className={style.whiteBox}>
-        <RoomImg />
-        <RoomImg />
-        <RoomImg />
+      <div className={style.whiteCard} />
+      <div className={style.hiddenCard}>
+        {slide.map((el, idx) => {
+          return (
+            <RoomImg
+              className={style.cards}
+              url={el.url}
+              id={el.id}
+              key={el.id}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/detail/rooms/Rooms.module.css
+++ b/src/pages/detail/rooms/Rooms.module.css
@@ -50,6 +50,18 @@
   cursor: pointer;
 }
 
-.whiteBox {
+.whiteCard {
   width: 50%;
+}
+
+.hiddenCard {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  gap: 30px;
+  right: 0px;
+  height: 500px;
+  width: 65%;
+  overflow: hidden;
 }

--- a/src/pages/detail/rooms/roomImg/RoomImg.js
+++ b/src/pages/detail/rooms/roomImg/RoomImg.js
@@ -1,14 +1,10 @@
 import React from 'react';
 import style from './RoomImg.module.css';
 
-const RoomImg = () => {
+const RoomImg = ({ url, id }) => {
   return (
     <div className={style.card}>
-      <img
-        src="https://images.unsplash.com/photo-1564078516393-cf04bd966897?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8M3x8cm9vbXxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=600&q=60"
-        alt="room image"
-        className={style.roomImage}
-      />
+      <img src={url} alt={id} className={style.roomImage} />
       <div className={style.infoLayer}>
         <div className={style.roomCondition}>
           <span className={style.roomName}>THE LAKE</span>

--- a/src/pages/detail/rooms/roomImg/RoomImg.module.css
+++ b/src/pages/detail/rooms/roomImg/RoomImg.module.css
@@ -1,8 +1,6 @@
 .card {
+  position: relative;
   width: 400px;
-  position: absolute;
-  top: 50px;
-  left: 600px;
 }
 
 .card:hover {
@@ -20,9 +18,9 @@
   justify-content: center;
   gap: 140px;
   position: absolute;
-  top: 70%;
+  top: 71%;
   width: 100%;
-  height: 29%;
+  height: 28%;
   background-color: rgba(0, 0, 0, 0.7);
   color: white;
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [x] 디자인 구현

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 디테일 페이지 숙소 외관 사진 슬라이드 구현
- 디테일 페이지 객실 내부 사진 슬라이드 레이아웃 구현
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 숙소 외관 사진 슬라이드 기능 구현 (프론트)
- 목데이터를 만들어 배열에 사진을 담고 state값으로 보여줄 사진 순서를 관리한다.
- 버튼으로 state 값을 관리하고 해당 숫자의 사진을 화면에 출력한다.

2. 객실
- 객실 슬라이드를 담는 요소 구현
- 객실 슬라이드 레이아웃 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- state값 관리 하는 법을 더 배웠습니다.
- 슬라이드 레이아웃을 구현하는 법을 익혔습니다.

<br />

## :: 기타 질문 및 특이 사항
- 객실 슬라이드 레이아웃만 구현하고 기능은 백엔드를 마무리한 다음 구현할까 싶습니다.
